### PR TITLE
mark bfd/vrrp tests as xfail

### DIFF
--- a/ansible/hedgehog_deployment_script.sh
+++ b/ansible/hedgehog_deployment_script.sh
@@ -5,7 +5,7 @@
 
 MGMT_CONTAINER=`docker ps | awk '/docker-sonic-mgmt/ { print $NF }'`
 CURRENT_TOPO_CONTAINER=`docker ps | awk '/sonicdev-microsoft.azurecr.io/ { print $NF }'`
-SONIC_MGMT_REPO="sonic-mgmt_dev_202205"
+SONIC_MGMT_REPO="sonic-mgmt"
 
 pre_check () {
   echo "Pre check"
@@ -36,7 +36,7 @@ deploy_topo () {
 
 post_check () {
   echo "Verify env"
-  docker exec -i "$MGMT_CONTAINER" bash -c "cd /data/$SONIC_MGMT_REPO/tests && export ANSIBLE_CONFIG=../ansible; export ANSIBLE_LIBRARY=../ansible; pytest --inventory ../ansible/veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --showlocals --assert plain --show-capture no -rav --allow_recover --topology vs,any --module-path ../ansible/library --skip_sanity ./bgp/test_bgp_fact.py"
+  docker exec -i "$MGMT_CONTAINER" bash -c "cd /data/$SONIC_MGMT_REPO/tests && export ANSIBLE_CONFIG=../ansible; export ANSIBLE_LIBRARY=../ansible; pytest --inventory ../ansible/veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --showlocals --assert plain --show-capture no -rav --allow_recover --topology vs,any --module-path ../ansible/library --skip_sanity ./test_hedgehog_smoke.py"
 
   if [ $? -eq 0 ]; then
     echo "Topo is deployed successfully."
@@ -48,4 +48,5 @@ post_check () {
 pre_check
 remove_topo
 deploy_topo
+sleep 120
 post_check

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -924,3 +924,18 @@ vxlan/test_vxlan_ecmp.py:
     reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on 4600c and 8102."
     conditions:
       - "(is_multi_asic==True) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-8102_64h_o-r0'])"
+
+#######################################
+#####       hedgehog_smoke        #####
+#######################################
+test_hedgehog_smoke.py::test_vrrp_smoke:
+  xfail:
+    reason: "Hedgehog: VRRP is not enabled yet. DEV-?"
+    conditions:
+      - "asic_type in ['vs']"
+
+test_hedgehog_smoke.py::test_bfd_smoke:
+  xfail:
+    reason: "Hedgehog: BFD is not enabled yet. DEV-?"
+    conditions:
+      - "asic_type in ['vs']"

--- a/tests/test_hedgehog_smoke.py
+++ b/tests/test_hedgehog_smoke.py
@@ -231,7 +231,7 @@ def test_syslog_smoke(setup):
         fake_syslog_server_ip = "1.1.1.1"
         try:
             # verify rsyslogd process
-            pytest_assert(is_rsyslogd_proc, "There is no running vrrpd process, but should be.")
+            pytest_assert(is_rsyslogd_proc, "There is no running 'rsyslogd' process, but should be.")
             # add fake syslog ip server verify it is added
             duthost.shell("sudo config syslog add {}".format(fake_syslog_server_ip), module_ignore_errors=True)
             syslog_servers = duthost.shell("show runningconfiguration syslog", module_ignore_errors=True)


### PR DESCRIPTION
- [test] fix process name in assert msg
- [core] update deployment_script
- [test] mark vrrp/bfd as xfail


```
test_hedgehog_smoke.py::test_container_state[snmp] PASSED                                   [  5%]
test_hedgehog_smoke.py::test_container_state[dhcp_relay] PASSED                             [ 10%]
test_hedgehog_smoke.py::test_container_state[mgmt-framework] PASSED                         [ 15%]
test_hedgehog_smoke.py::test_container_state[swss] PASSED                                   [ 20%]
test_hedgehog_smoke.py::test_container_state[lldp] PASSED                                   [ 25%]
test_hedgehog_smoke.py::test_container_state[pmon] PASSED                                   [ 30%]
test_hedgehog_smoke.py::test_container_state[database] PASSED                               [ 35%]
test_hedgehog_smoke.py::test_container_state[telemetry] PASSED                              [ 40%]
test_hedgehog_smoke.py::test_container_state[bgp] PASSED                                    [ 45%]
test_hedgehog_smoke.py::test_container_state[radv] PASSED                                   [ 50%]
test_hedgehog_smoke.py::test_container_state[teamd] PASSED                                  [ 55%]
test_hedgehog_smoke.py::test_container_state[syncd] PASSED                                  [ 60%]
test_hedgehog_smoke.py::test_bgp_smoke PASSED                                               [ 65%]
test_hedgehog_smoke.py::test_bfd_smoke XFAIL                                                [ 70%]
test_hedgehog_smoke.py::test_vrrp_smoke XFAIL                                               [ 75%]
test_hedgehog_smoke.py::test_syslog_smoke PASSED                                            [ 80%]
test_hedgehog_smoke.py::test_database_smoke PASSED                                          [ 85%]
test_hedgehog_smoke.py::test_syncd_smoke PASSED                                             [ 90%]
test_hedgehog_smoke.py::test_swss_smoke PASSED                                              [ 95%]
test_hedgehog_smoke.py::test_pmon_smoke PASSED                                              [100%]
```