### PR TITLE
[test] extend loganalyzer regex for snmp_smoke

### DIFF
--- a/tests/test_hedgehog_smoke.py
+++ b/tests/test_hedgehog_smoke.py
@@ -447,7 +447,7 @@ def test_ntp_smoke(setup):
     run_shell_helper(duthost, shell_conf_ntp, "CLI \"{}\" command error".format(shell_conf_ntp), do_assert=True)
 
 
-def test_snmp_smoke(setup):
+def test_snmp_smoke(setup, loganalyzer):
     """Verify that 'snmp' container is running according to INCLUDE_SNMP (build_metadata.yaml).
         If so, make basic SNMP configuration and verify that configuration is applied"""
     duthost = setup['duthost']
@@ -460,6 +460,14 @@ def test_snmp_smoke(setup):
     snmp_test_user = "SNMPSmokeTestUser"
     shell_conf_snmp_user_add = shell_conf_snmp + " user add " + snmp_test_user + " noAuthNoPriv RO"
     shell_conf_snmp_user_del = shell_conf_snmp + " user del " + snmp_test_user
+
+    # https://github.com/sonic-net/sonic-buildimage/issues/7862
+    # loganalyzer fail for 'vs'
+    if duthost.facts['asic_type'] == "vs" and duthost.facts['hwsku'] == "Force10-S6000":
+        for host in loganalyzer:
+            loganalyzer[host].ignore_regex.append(r".*ERR wrong number of arguments for 'hset' command: Input/output error: Input/output error")
+            loganalyzer[host].ignore_regex.append(r".*ERR sonic-db-cli: :- guard: RedisReply catches system_error: command:.*ERR wrong number of arguments for 'hset' command: Input/output error")
+
 
     # Check metadata
     check_container_sanity_helper(config, container)


### PR DESCRIPTION
loganalyzer fails for test_snmp_smoke 

```
Failed: Processes "['analyze_logs--<MultiAsicSonicHost vlab-01>']" failed with exit code "1"
Exception:
expected_match: 0
expected_missing_match: 0
match: 4
....
Feb 15 01:00:34.013843 vlab-01 INFO snmp.sh[104466]: , reason: ERR wrong number of arguments for 'hset' command: Input/output error: Input/output error
Feb 15 01:00:36.703001 vlab-01 ERR sonic-db-cli: :- guard: RedisReply catches system_error: command: *3#015#012$4#015#012HSET#015#012$25#015#012DEVICE_METADATA|localhost#015#012$21#015#012chassis_serial_number#015#012, reason: ERR wrong number of arguments for 'hset' command: Input/output error
```


it is cause by restarting `snmp` 

added this kind of errors into `ignore_regex`