### PR TITLE
Add notification when run unmapped test

### DIFF
--- a/tests/hedgehog/env/vsTestbed-01-t0.yaml
+++ b/tests/hedgehog/env/vsTestbed-01-t0.yaml
@@ -7,6 +7,7 @@
   "topo": "t0,any"
   "host_pattern": "vlab-01"
   "report_base_dir": "/data/sonic-mgmt/report/vsTestbed-01/t0/"
+  "unmapped_tc_file": "unmapped_tests.txt"
 "testops":
   "tag": "generated dynamically in runner.py"
   "endpoint": "https://hedgehog.testops.cloud"

--- a/tests/hedgehog/script/jenkins_helper.sh
+++ b/tests/hedgehog/script/jenkins_helper.sh
@@ -22,6 +22,7 @@ done
 
 SONIC_MGMT_WD="/home/hedgehog/sonic-mgmt"
 SSH_OPTIONS="-o ServerAliveInterval=30 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+UNMAPPED_TESTS_FILE_NAME="unmapped_tests.txt"
 
 MGMT_CONTAINER=`ssh -q $SSH_OPTIONS $SERVER "docker ps -f ancestor=docker-sonic-mgmt-hedgehog:master --format {{.Names}}"`
 REPORT_PREFIX=`ssh -q $SSH_OPTIONS $SERVER "cat $SONIC_MGMT_WD/tests/$TESTBED | yq .testbed.report_base_dir"`
@@ -70,4 +71,5 @@ copyArtifacts() {
     mkdir -p reports
     scp -r $SSH_OPTIONS $SERVER:$SONIC_MGMT_WD/$prefix/$REPORT_DIR reports/
     scp -r $SSH_OPTIONS $SERVER:$SONIC_MGMT_WD/tests/report.html reports/
+    mv reports/$REPORT_DIR/$UNMAPPED_TESTS_FILE_NAME reports/
 }

--- a/tests/hedgehog/script/jenkins_helper.sh
+++ b/tests/hedgehog/script/jenkins_helper.sh
@@ -22,12 +22,12 @@ done
 
 SONIC_MGMT_WD="/home/hedgehog/sonic-mgmt"
 SSH_OPTIONS="-o ServerAliveInterval=30 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-UNMAPPED_TESTS_FILE_NAME="unmapped_tests.txt"
 
 MGMT_CONTAINER=`ssh -q $SSH_OPTIONS $SERVER "docker ps -f ancestor=docker-sonic-mgmt-hedgehog:master --format {{.Names}}"`
 REPORT_PREFIX=`ssh -q $SSH_OPTIONS $SERVER "cat $SONIC_MGMT_WD/tests/$TESTBED | yq .testbed.report_base_dir"`
 DUT_IP=`ssh -q $SSH_OPTIONS $SERVER "cat $SONIC_MGMT_WD/tests/$TESTBED | yq .testbed.dut_ip"`
 REPORT_DIR="$(date +%Y%m%d)-$REPORT_DIR-b$CI_BUILD_NUMBER"
+UNMAPPED_TC_FILE_NAME=`ssh -q $SSH_OPTIONS $SERVER "cat $SONIC_MGMT_WD/tests/$TESTBED | yq .testbed.unmapped_tc_file"`
 
 
 redeployEnv() {
@@ -71,5 +71,5 @@ copyArtifacts() {
     mkdir -p reports
     scp -r $SSH_OPTIONS $SERVER:$SONIC_MGMT_WD/$prefix/$REPORT_DIR reports/
     scp -r $SSH_OPTIONS $SERVER:$SONIC_MGMT_WD/tests/report.html reports/
-    mv reports/$REPORT_DIR/$UNMAPPED_TESTS_FILE_NAME reports/
+    test -f reports/$REPORT_DIR/$UNMAPPED_TC_FILE_NAME && mv reports/$REPORT_DIR/$UNMAPPED_TC_FILE_NAME reports/
 }

--- a/tests/hedgehog/script/jenkins_helper.sh
+++ b/tests/hedgehog/script/jenkins_helper.sh
@@ -71,5 +71,5 @@ copyArtifacts() {
     mkdir -p reports
     scp -r $SSH_OPTIONS $SERVER:$SONIC_MGMT_WD/$prefix/$REPORT_DIR reports/
     scp -r $SSH_OPTIONS $SERVER:$SONIC_MGMT_WD/tests/report.html reports/
-    test -f reports/$REPORT_DIR/$UNMAPPED_TC_FILE_NAME && mv reports/$REPORT_DIR/$UNMAPPED_TC_FILE_NAME reports/
+    mv reports/$REPORT_DIR/$UNMAPPED_TC_FILE_NAME reports/
 }

--- a/tests/hedgehog_test_runner.py
+++ b/tests/hedgehog_test_runner.py
@@ -159,6 +159,7 @@ def build_run_test_cmd(testbed_data, test_list, report_dir_name):
 
 
 def update_allure_report():
+    unmapped_tests = []
     tests_to_grup_map = read_yaml(MAPPING_TEST_TO_GROUP_FILE)
 
     # iterate over files with test results in the Allure directory
@@ -173,12 +174,18 @@ def update_allure_report():
             layer_label["value"] = tests_to_grup_map[test_info["fullName"]]
         else:
             layer_label["value"] ="Default"
+            unmapped_tests.append(test_info["fullName"])
 
         test_info["labels"].append(layer_label)
 
         #rewrite updated JSON
         with open(file, "w") as outfile:
             json.dump(test_info, outfile)
+
+        #write list with unmapped tests to file
+        if unmapped_tests:
+            with open(FULL_REPORT_DIR_PATH +'/unmapped_tests.txt', 'w') as outfile:
+                outfile.write('\n'.join(unmapped_tests))
 
 
 def run_cmd(cmd, print_only):

--- a/tests/hedgehog_test_runner.py
+++ b/tests/hedgehog_test_runner.py
@@ -158,8 +158,9 @@ def build_run_test_cmd(testbed_data, test_list, report_dir_name):
     return cmd
 
 
-def update_allure_report():
+def update_allure_report(testbed_data):
     unmapped_tests = []
+    unmapped_tc_file = "{}/{}".format(FULL_REPORT_DIR_PATH, testbed_data['testbed']['unmapped_tc_file'])
     tests_to_grup_map = read_yaml(MAPPING_TEST_TO_GROUP_FILE)
 
     # iterate over files with test results in the Allure directory
@@ -184,7 +185,7 @@ def update_allure_report():
 
         #write list with unmapped tests to file
         if unmapped_tests:
-            with open(FULL_REPORT_DIR_PATH +'/unmapped_tests.txt', 'w') as outfile:
+            with open(unmapped_tc_file, 'w') as outfile:
                 outfile.write('\n'.join(unmapped_tests))
 
 
@@ -239,7 +240,7 @@ def main(argv):
     run_cmd(test_run_cmd, is_print_only)
 
     # extend allure report with new labels
-    update_allure_report()
+    update_allure_report(testbed)
 
     # upload result into testops via `allurectl`
     allurectl_upload_cmd = build_allurectl_cmd(testbed, metadata, sonic_ver, args.ci_build_number, args.allurectl_token)

--- a/tests/hedgehog_test_runner.py
+++ b/tests/hedgehog_test_runner.py
@@ -184,9 +184,8 @@ def update_allure_report(testbed_data):
             json.dump(test_info, outfile)
 
         #write list with unmapped tests to file
-        if unmapped_tests:
-            with open(unmapped_tc_file, 'w') as outfile:
-                outfile.write('\n'.join(unmapped_tests))
+        with open(unmapped_tc_file, 'w') as outfile:
+            outfile.write('\n'.join(unmapped_tests))
 
 
 def run_cmd(cmd, print_only):


### PR DESCRIPTION
**How did you do it?**
1. Find tests name into [mapping_test_to_group.yaml](https://github.com/githedgehog/sonic-mgmt/blob/202205_hedgehog_dev/tests/hedgehog/mapping_test_to_group.yaml). 
If the test is absent will add it to **_unmapped_tests.txt_** file.
2. Jenkins reads **_unmapped_tests.txt_** and send a list of unmapped test to `#ci_notifications` Slack's channel.


**Result:** 
1. List of unmapped test in Jenkins log.
2. **_unmapped_tests.txt_** in builds artifact on Jenkins.
3. Notification in Slack channel:
![Screenshot from 2023-03-23 20-40-42](https://user-images.githubusercontent.com/68950226/227315956-cc3abb1d-b778-4596-a961-95256de5ba13.png)
