### PR TITLE
use the same creds for virt env as for hw env

### DIFF
--- a/ansible/group_vars/fanout/secrets.yml
+++ b/ansible/group_vars/fanout/secrets.yml
@@ -1,7 +1,7 @@
 # Please update the actual username and password according to your lab configuration
 
-ansible_ssh_user: user
-ansible_ssh_pass: password
+ansible_ssh_user: admin
+ansible_ssh_pass: YourPaSsWoRd
 fanout_mlnx_user: admin
 fanout_mlnx_password: admin
 fanout_sonic_user: admin

--- a/ansible/group_vars/lab/secrets.yml
+++ b/ansible/group_vars/lab/secrets.yml
@@ -1,8 +1,8 @@
-ansible_ssh_pass: password
-ansible_become_pass: password
+ansible_ssh_pass: YourPaSsWoRd
+ansible_become_pass: YourPaSsWoRd
 sonicadmin_user: admin
-sonicadmin_password: password
-sonicadmin_initial_password: password
+sonicadmin_password: YourPaSsWoRd
+sonicadmin_initial_password: YourPaSsWoRd
 
 console_login:
   console_telnet: 

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -30,7 +30,7 @@ sonic_latest:
       type: kvm
       hwsku: Force10-S6000
       serial_port: 9000
-      ansible_password: password
+      ansible_password: YourPaSsWoRd
       ansible_user: admin
     switch1:
       ansible_host: 10.0.0.100

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -90,7 +90,7 @@ all:
           type: kvm
           hwsku: Force10-S6000
           serial_port: 9000
-          ansible_password: password
+          ansible_password: YourPaSsWoRd
           ansible_user: admin
         vlab-02:
           ansible_host: 10.250.0.114

--- a/tests/hedgehog/env/vsTestbed-01-t0.yaml
+++ b/tests/hedgehog/env/vsTestbed-01-t0.yaml
@@ -2,7 +2,7 @@
 "testbed":
   "dut_ip": "10.250.0.101"
   "username": "admin"
-  "password": "password"
+  "password": "YourPaSsWoRd"
   "conf_name": "vms-kvm-t0"
   "topo": "t0,any"
   "host_pattern": "vlab-01"

--- a/tests/hedgehog/script/jenkins_helper.sh
+++ b/tests/hedgehog/script/jenkins_helper.sh
@@ -51,9 +51,6 @@ redeployEnv() {
 
     echo "Reboot DUT to apply changes"
     sshpass -p $DUT_PASS ssh $SSH_OPTIONS -o "ProxyCommand ssh $SSH_OPTIONS $SERVER -W %h:%p" $DUT_USER@$DUT_IP "sudo reboot"
-
-    echo "Apply hedgehog user patch"
-    ssh $SSH_OPTIONS $SERVER "cd $SONIC_MGMT_WD && git apply test_hedgehog_user.patch"
 }
 
 runTests() {


### PR DESCRIPTION
- adjust jenkins_helper to default sonic creds
- use the same creds for virt env as for hw env