### PR TITLE
[core] keep allurectl in local repo

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -251,11 +251,11 @@ fi
 # Install pyyaml, it used by hedgehog_test_runner.py. do not use env-python3, it is virt env for ptf container.
 RUN /usr/local/sbin/pip3 install pyyaml
 
-# Download allurectl for uploading test result on 'testops'
-RUN /usr/local/sbin/wget https://github.com/allure-framework/allurectl/releases/latest/download/allurectl_linux_386 -O /opt/allurectl
-RUN chmod +x /opt/allurectl
-
 EOF
+
+    log_info "add step to copy allurectl into opt in Dockerfile.j2"
+    eval "echo \"# Download allurectl for uploading test result on 'testops'\" >> ${TMP_DIR}/Dockerfile.j2"
+    eval "echo \"COPY ${PWD}/tests/hedgehog/script/allurectl /opt/allurectl\" >> ${TMP_DIR}/Dockerfile.j2"
 
     log_info "prepare an environment file: ${TMP_DIR}/data.env"
     cat <<EOF > "${TMP_DIR}/data.env"


### PR DESCRIPTION
This PR is going to fix
1 an issue with permission
```
 => ERROR [24/25] RUN /usr/local/sbin/wget https://github.com/allure-framework/allurectl/releases/latest/download/allurectl_linux_386 -O /opt/allurectl                                               2.1s
------                                                                                                                                                                                                     
 > [24/25] RUN /usr/local/sbin/wget https://github.com/allure-framework/allurectl/releases/latest/download/allurectl_linux_386 -O /opt/allurectl:
#0 1.998 /opt/allurectl: Permission denied
------
Dockerfile:76
--------------------
  74 |     
  75 |     # Download allurectl for uploading test result on 'testops'
  76 | >>> RUN /usr/local/sbin/wget https://github.com/allure-framework/allurectl/releases/latest/download/allurectl_linux_386 -O /opt/allurectl
  77 |     RUN chmod +x /opt/allurectl
  78 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c /usr/local/sbin/wget https://github.com/allure-framework/allurectl/releases/latest/download/allurectl_linux_386 -O /opt/allurectl" did not complete successfully: exit code: 1
```
2 and potential issue that `allurectl` will not be available via URL for no good reason.
